### PR TITLE
Add unified BCI CLI wrapper and Makefile targets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -205,3 +205,14 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+
+# Project artifacts
+data/
+datasets/
+outputs/
+cache/
+.mne/
+*.fif
+*.edf
+*.set
+*.vmrk

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #   - Fournir des commandes pratiques pour l’entraînement et la prédiction du modèle
 # ========================================================================================
 
-.PHONY: install lint format type test cov mut train predict-nocheck viz tv-bench-all tv-bench-% activate deactivate
+.PHONY: install lint format type test cov mut train predict viz tv-bench-all tv-bench-% activate deactivate
 
 VENV = .venv
 VENV_BIN = $(VENV)/bin/activate
@@ -64,13 +64,18 @@ mut:
 # Commandes liées au modèle (Poetry)
 # ----------------------------------------------------------------------------------------
 
-# Entraînement du modèle : génère le fichier theta.json
-train:
-	$(POETRY) train
+TRAIN_SUBJECT ?= S01
+TRAIN_RUN ?= R01
+PREDICT_SUBJECT ?= $(TRAIN_SUBJECT)
+PREDICT_RUN ?= $(TRAIN_RUN)
 
-# Prédiction du prix pour une valeur donnée (km)
-predict-nocheck:
-	@$(POETRY) predict
+# Entraînement du modèle : exemple minimal avec sujet et run de démonstration
+train:
+        $(POETRY) python mybci.py $(TRAIN_SUBJECT) $(TRAIN_RUN) train
+
+# Prédiction : exemple minimal réutilisant les identifiants ci-dessus
+predict:
+        $(POETRY) python mybci.py $(PREDICT_SUBJECT) $(PREDICT_RUN) predict
 
 
 

--- a/README.md
+++ b/README.md
@@ -169,8 +169,17 @@ pipeline = Pipeline([
 
 # 🔍 5. Entraînement
 
+L’interface CLI unifiée `mybci.py` lance les modules `tpv.train` et `tpv.predict` avec
+des identifiants explicites :
+
 ```bash
-poetry run python scripts/train.py subject_id run_id
+python mybci.py S01 R01 train
+```
+
+Raccourci Makefile avec des valeurs par défaut modifiables :
+
+```bash
+make train TRAIN_SUBJECT=S01 TRAIN_RUN=R01
 ```
 
 Affiche :
@@ -183,8 +192,16 @@ Affiche :
 
 # ⚡ 6. Prédiction en pseudo temps réel
 
+Réutilise la même CLI pour la phase inference :
+
 ```bash
-poetry run python scripts/predict.py subject_id run_id
+python mybci.py S01 R01 predict
+```
+
+Ou via le Makefile :
+
+```bash
+make predict PREDICT_SUBJECT=S01 PREDICT_RUN=R01
 ```
 
 Contraintes :

--- a/mybci.py
+++ b/mybci.py
@@ -1,0 +1,41 @@
+"""Command line entrypoint for TPV BCI workflows."""
+
+import argparse
+import subprocess
+import sys
+from typing import Sequence
+
+
+def _call_module(module_name: str, subject: str, run: str) -> int:
+    """Invoke a TPV module with the provided identifiers via ``python -m``."""
+    command: list[str] = [sys.executable, "-m", module_name, subject, run]
+    completed = subprocess.run(command, check=False)
+    return completed.returncode
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Pilote un workflow d'entraînement ou de prédiction TPV",
+        usage="python mybci.py <subject> <run> {train,predict}",
+    )
+    parser.add_argument("subject", help="Identifiant du sujet (ex: S01)")
+    parser.add_argument("run", help="Identifiant du run (ex: R01)")
+    parser.add_argument(
+        "mode",
+        choices=("train", "predict"),
+        help="Choix du pipeline à lancer",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+
+    if args.mode == "train":
+        return _call_module("tpv.train", args.subject, args.run)
+
+    return _call_module("tpv.predict", args.subject, args.run)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add an argparse-based mybci.py entrypoint that dispatches to the tpv train/predict modules
- provide make train/make predict shortcuts with example subject/run identifiers
- document the new CLI usage and ignore common dataset/cache artifacts

## Testing
- python mybci.py --help

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924bb40170c832496af06c561252733)